### PR TITLE
Replaced bindings with haskell-wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hello-wayland-hs
-This is a reimplementation of https://github.com/emersion/hello-wayland but with haskell FFI bindings to libwayland-client.  The bindings here are manually created, rather than generated from the protocol XML files.
+This is a reimplementation of https://github.com/emersion/hello-wayland but with haskell FFI bindings to libwayland-client.
 
 The purpose is to show:
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,70 +6,70 @@ import Constants
 
 import Data.IORef
 import Foreign
-import Foreign.C.String
 import Control.Concurrent.MVar
 import Control.Monad (when, unless)
 import Control.Concurrent (myThreadId)
+import Data.Maybe (fromJust, isJust)
+import Data.Coerce (coerce)
+
+import qualified Graphics.Wayland.Client as WLC
+
+type GlobalFn' = WLC.Registry -> Word -> String -> Word -> IO ()
 
 -- Listener Callbacks
-myGlobal :: Ptr SeatListener -> Ptr XdgWmBaseListener -> MVar Globals -> GlobalFn
-myGlobal seatL xdgbL m _ reg n iface _ = do
-    name <- peekCString iface
+myGlobal :: WLC.SeatListener -> Ptr XdgWmBaseListener -> MVar Globals -> GlobalFn'
+myGlobal seatL xdgbL m reg n name _ = do
     case name of
          x | x == shmName -> do
              putStrLn "Found shm object to register"
-             shm <- wlRegistryBind reg n wlShmInterface 1
-             modifyMVar_ m (\g -> pure (g { unshm = castPtr shm }))
+             shm <- WLC.registryBindShm reg n name 1
+             modifyMVar_ m (\g -> pure (g { unshm = shm }))
          x | x == seatName -> do
              putStrLn "Found seat object to register"
-             seat <- wlRegistryBind reg n wlSeatInterface 1
-             _ <- wlSeatAddListener (castPtr seat) seatL nullPtr
-             modifyMVar_ m (\g -> pure (g { unseat = castPtr seat }))
+             seat <- WLC.registryBindSeat reg n name 1
+             _ <- WLC.seatSetListener seat seatL
+             modifyMVar_ m (\g -> pure (g { unseat = seat }))
          x | x == compositorName -> do
              putStrLn "Found compositor object to register"
-             comp <- wlRegistryBind reg n wlCompositorInterface 1
-             modifyMVar_ m (\g -> pure (g { uncomp = castPtr comp }))
+             comp <- WLC.registryBindCompositor reg n name 1
+             modifyMVar_ m (\g -> pure (g { uncomp = comp }))
          x | x == xdgShellName -> do
              putStrLn "Found xdg shell object to register"
-             xdgb <- wlRegistryBind reg n xdgWmBaseInterface 1
+             xdgb <- wlRegistryBind (coerce reg) (fromIntegral n) xdgWmBaseInterface 1
              _ <- xdgWmBaseAddListener (castPtr xdgb) xdgbL nullPtr
              modifyMVar_ m (\g -> pure (g { unxdgwm = castPtr xdgb }))
          _ -> pure ()
 
-myGlobalRemove :: GlobalRemoveFn
-myGlobalRemove _ _ _ = putStrLn "TODO: global remove callback"
+myGlobalRemove :: WLC.Registry -> Word -> IO ()
+myGlobalRemove _ _ = putStrLn "TODO: global remove callback"
 
 -- Global objects from the registry, captured in one object
 -- since there is only one callback for the listener
 data Globals = Globals
-    { unshm :: Ptr Shm
-    , unseat :: Ptr Seat
-    , uncomp :: Ptr Compositor
+    { unshm :: WLC.Shm
+    , unseat :: WLC.Seat
+    , uncomp :: WLC.Compositor
     , unxdgwm :: Ptr XdgWmBase } deriving Show
 
-mkRegistryListener :: MVar Globals -> IO (Ptr RegistryListener)
+mkRegistryListener :: MVar Globals -> IO (WLC.RegistryListener)
 mkRegistryListener globals = do
-    seatL <- mkWlSeatListener
+    let seatL = mkWlSeatListener
     xdgbL <- mkXdgBaseListener
-    gbFn <- registryListenerGlobalWrapper (myGlobal seatL xdgbL globals)
-    gbrFn <- registryListenerGlobalRemoveWrapper myGlobalRemove
-    new RegistryListener { global = gbFn, globalRemove =  gbrFn}
+    let gbFn = (myGlobal seatL xdgbL globals)
+    return WLC.RegistryListener { registryGlobal = gbFn, registryGlobalRemove =  myGlobalRemove}
 
-mySeatCapabilities :: CapabilitesFn
-mySeatCapabilities _ s cap = do
+mySeatCapabilities :: WLC.Seat -> Word -> IO ()
+mySeatCapabilities _ cap = do
     when (cap .&. 1 == 1) $ do
-        _ <- wlSeatGetPointer s
+--         _ <- wlSeatGetPointer s
         myid <- myThreadId
         putStrLn $ show myid ++ " TODO add pointer listener"
 
-mySeatName :: SlNameFn
-mySeatName _ _ n = putStrLn $ "seat name: " ++ show n
+mySeatName :: WLC.Seat -> String -> IO ()
+mySeatName _  n = putStrLn $ "seat name: " ++ show n
 
-mkWlSeatListener :: IO (Ptr SeatListener)
-mkWlSeatListener = do
-    cp <- seatListenerCapabilitiesWrapper mySeatCapabilities
-    np <- seatListenerNameWrapper mySeatName
-    new SeatListener { slCapabilities = cp, slName = np }
+mkWlSeatListener :: WLC.SeatListener
+mkWlSeatListener = WLC.SeatListener { seatCapabilities = mySeatCapabilities , seatName = mySeatName }
 
 myPing :: PingFn
 myPing _ _ _ = pure ()
@@ -112,55 +112,55 @@ mkXdgTopLevelListener running = do
 whileM :: Monad m => m Bool -> m ()
 whileM act = act >>= flip when (whileM act)
 
-notConfigured :: Ptr Display -> MVar Bool -> IO Bool
+notConfigured :: WLC.Display -> MVar Bool -> IO Bool
 notConfigured dpy mv = do
-    nEvents <- wlDisplayDispatch dpy
+    nEvents <- WLC.displayDispatch dpy
     configured <- readMVar mv
-    return $ nEvents /= -1 && not configured
+    return $ isJust nEvents && not configured
 
-notClosed :: Ptr Display -> IORef Bool -> IO Bool
+notClosed :: WLC.Display -> IORef Bool -> IO Bool
 notClosed dpy r = do
-    nEvents <- wlDisplayDispatch dpy
+    nEvents <- WLC.displayDispatch dpy
     running <- readIORef r
-    return $ nEvents /= -1 && running
+    return $ isJust nEvents && running
 
 main :: IO ()
 main = do
     putStrLn "Hello, Wayland!"
-    globals <- newMVar Globals  { unshm = nullPtr
-                                , unseat = nullPtr
-                                , uncomp = nullPtr
+    globals <- newMVar Globals  { unshm = WLC.Shm nullPtr
+                                , unseat = WLC.Seat nullPtr
+                                , uncomp = WLC.Compositor nullPtr
                                 , unxdgwm = nullPtr }
-    dpy <- wlDisplayConnect nullPtr
-    reg <- wlDisplayGetRegistry dpy
+    dpy <- fromJust <$> WLC.displayConnect
+    reg <- WLC.displayGetRegistry dpy
     regL <- mkRegistryListener globals
-    _ <- wlRegistryAddListener reg regL nullPtr
+    _ <- WLC.registrySetListener reg regL
     -- Do a roundtrip, blocking for requests + events to go + come
-    _ <- wlDisplayRountrip dpy
+    _ <- WLC.displayRoundtrip dpy
     gs <- readMVar globals
     print gs
     -- TODO replace with ConT for early "break"
-    when (unshm gs == nullPtr || uncomp gs == nullPtr || unxdgwm gs == nullPtr) $ putStrLn "Things are going to break..."
+    when (unshm gs == (coerce nullPtr) || uncomp gs == (coerce nullPtr) || unxdgwm gs == (coerce nullPtr)) $ putStrLn "Things are going to break..."
     -- WL Surface is needed for an XDG Surface.  Commits happen against it
     -- TopLevel represents "normal" desktop windows (from xdg-desktop)
-    surf <- wlCompositorCreateSurface (uncomp gs)
-    xdgSurf <- xdgWmBaseGetXdgSurface (unxdgwm gs) surf
+    surf <- WLC.compositorCreateSurface (uncomp gs)
+    xdgSurf <- xdgWmBaseGetXdgSurface (unxdgwm gs) (coerce surf)
     xdgTop <- xdgSurfaceGetTopLevel xdgSurf
     -- XDG listeners
     confVar <- newMVar False
     running <- newIORef True
-    xdgSL <- mkXdgSurfaceListener surf confVar
+    xdgSL <- mkXdgSurfaceListener (coerce surf) confVar
     xdgTL <- mkXdgTopLevelListener running
     _ <- xdgSurfaceAddListener xdgSurf xdgSL nullPtr
     _ <- xdgTopLevelAddListener xdgTop xdgTL nullPtr
     -- initial commit and wait for first configure
-    wlSurfaceCommit surf
+    WLC.surfaceCommit surf
     whileM (notConfigured dpy confVar)
     -- Create WL buffer, attach to surface and commit the surface
-    buff <- createBuffer (unshm gs)
-    wlSurfaceAttach surf buff 0 0
-    wlSurfaceCommit surf
+    buff <- createBuffer (coerce (unshm gs))
+    WLC.surfaceAttach surf (Just buff) 0 0
+    WLC.surfaceCommit surf
     -- dispatch until toplevel close
     whileM (notClosed dpy running)
     -- Cleanup TODO
-    wlDisplayDisconnect dpy
+    WLC.displayDisconnect dpy

--- a/hello-wayland-hs.cabal
+++ b/hello-wayland-hs.cabal
@@ -68,7 +68,7 @@ executable hello-wayland-hs
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    hello-wayland-hs, base >=4.20.0.0
+    build-depends:    hello-wayland-hs, base >=4.20.0.0, haskell-wayland
 
     -- Directories containing source files.
     hs-source-dirs:   app

--- a/src/Buffer.hs
+++ b/src/Buffer.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString as B
 
 import Shm
 import MyModel (Shm, Buffer, wlShmCreatePool, wlShmPoolCreateBuffer)
+import qualified Graphics.Wayland.Client as WLC
 
 -- convenience
 fi :: forall a b. (Integral a, Num b) => a -> b
@@ -29,7 +30,7 @@ size = height * stride
 -- Enum from C headers
 wlShmFormatARGB8888 = 0
 
-createBuffer :: Ptr Shm -> IO (Ptr Buffer)
+createBuffer :: WLC.Shm -> IO (WLC.Buffer)
 createBuffer shm = do
     -- Allocate a shared memory file with the right size
     fd <- createShmFile size
@@ -37,8 +38,8 @@ createBuffer shm = do
     -- Map the shared memory file
     shmData <- mmap nullPtr (fi size) (protRead <> protWrite)
                     (mkMmapFlags mapShared mempty) (fi fd) 0
-    shmPool <- wlShmCreatePool shm fd size
-    buffer <- wlShmPoolCreateBuffer shmPool 0 width height stride wlShmFormatARGB8888
+    shmPool <- WLC.shmCreatePool shm (fromIntegral fd) (fromIntegral size)
+    buffer <- WLC.shmPoolCreateBuffer shmPool 0 (fi width) (fi height) (fi stride) (fi wlShmFormatARGB8888)
     -- Now that we've mapped the file and created the wl_buffer, we no longer
     -- need to keep the file descriptor opened
     closeFD fd

--- a/src/MyModel.hsc
+++ b/src/MyModel.hsc
@@ -1,3 +1,5 @@
+-- Manual first attempt at writing client bindings to libwayland-client
+-- Mostly replaced with haskell-wayland bindings
 module MyModel where
 
 #include <wayland-client.h>


### PR DESCRIPTION
Replaces the manually created bindings to libwayland-client with those generated by haskell-wayland.  The new bindings are notably less "raw C" and leave the marshaling details to generated code.